### PR TITLE
feat: Authorize.tsx authorizes for walletCanister, not only alice/bob

### DIFF
--- a/wallet_ui/components/routes/Authorize.tsx
+++ b/wallet_ui/components/routes/Authorize.tsx
@@ -26,7 +26,7 @@ import AuthenticationButton from "../authentication/AuthenticationButton";
 import AuthenticationContext from "../authentication/AuthenticationContext";
 import { makeLog } from "@dfinity/agent";
 // @ts-ignore
-// import walletCanister from 'ic:canisters/wallet';
+import walletCanister from 'ic:canisters/wallet';
 // @ts-ignore
 import aliceCanister from 'ic:canisters/alice';
 // @ts-ignore
@@ -174,7 +174,7 @@ export function Authorize({ dark }: { dark: boolean }) {
                 request={{
                   scope: [
                     ...[
-                      // walletCanister,
+                      walletCanister,
                       aliceCanister,
                       bobCanister,
                     ].map(c => ({


### PR DESCRIPTION
I believe this breaks because:
* dfx build wallet wants to run wallet/build.sh, which runs `npm run build`
* this tries to webpack everything
* Authorization.tsx now depends on `ic:canisters/wallet`, so webpack tries to resolve this to the built wallet js,
  * but WAIT, that's not there yet because this whole process is supposed to be building the wallet js.

Ideally we can `dfx build wallet` without that build script trying to webpack the module that depends on `@ic:canisters/wallet` (loop)

Why do we need this PR at all?
* Without this, after logging in, the wallet tries to verify it can make requests to all the canisters. The requests to alice,bob canisters succeed. The one to wallet gets rejected because the authenticationResponse did not include that canister in its scope. Everything appears to work, but there is a big error from the request to walletContract. It's briefly visible in this video. https://github.com/dfinity/wallet-rs/pull/24#issuecomment-777159979