### PR TITLE
re-enable requesting auth scope for the correct canister

### DIFF
--- a/wallet_ui/components/routes/Authorize.tsx
+++ b/wallet_ui/components/routes/Authorize.tsx
@@ -25,12 +25,6 @@ import { Copyright } from "../App";
 import AuthenticationButton from "../authentication/AuthenticationButton";
 import AuthenticationContext from "../authentication/AuthenticationContext";
 import { makeLog } from "@dfinity/agent";
-// // @ts-ignore
-// import walletCanister from 'ic:canisters/wallet';
-// // @ts-ignore
-// import aliceCanister from 'ic:canisters/alice';
-// // @ts-ignore
-// import bobCanister from 'ic:canisters/bob';
 
 SyntaxHighlighter.registerLanguage("bash", bash);
 SyntaxHighlighter.registerLanguage("plaintext", plaintext);


### PR DESCRIPTION
I believe this breaks because:
* dfx build wallet wants to run wallet/build.sh, which runs `npm run build`
* this tries to webpack everything
* Authorization.tsx now depends on `ic:canisters/wallet`, so webpack tries to resolve this to the built wallet js,
  * but WAIT, that's not there yet because this whole process is supposed to be building the wallet js.

Ideally we can `dfx build wallet` without that build script trying to webpack the module that depends on `@ic:canisters/wallet` (loop)

Why do we need this PR at all?
* Without this, after logging in, the wallet tries to verify it can make requests to all the canisters. The requests are cryptographicall valid, but will still be rejected because the access_token being used doesn't have any `scope` to its authorization, and it needs to explicitly include each canister.
* Assuming the github actions build didn't break, everything actually works fine. So this is really just a build/ci issue I'm hoping.

Other approaches:
* Anecdotally, it seems like after encountering this build error from `webpack`, you can simply try to build again and it will work because even though the first build failed, it did succeed it wrting the correct things to `./dfx/` that the second build can succeed. That's imperfect, but could at least land the functionality, so I'll probably just implement that real quick so we have something that's green.
  * **BUT** the real reason I'm making this PR is to ask what a more reasonable `wallet/build.sh` script could be that doesn't depend on itself already having been run.