### PR TITLE
remove all imports of makeLog from @dfinity/{agent,authentication}

### DIFF
--- a/wallet_ui/authentication-react.ts
+++ b/wallet_ui/authentication-react.ts
@@ -1,10 +1,9 @@
 import * as React from "react";
-import { useEffect, useRef } from "react";
 import { Authenticator, IdentitiesIterable } from "@dfinity/authentication"
 import { AuthenticatorSession, KeyedLocalStorage, readOrCreateSession, readSession, Session, writeSession } from "./session";
-import { AnonymousIdentity, createIdentityDescriptor, IdentityDescriptor, makeLog } from "@dfinity/agent";
-import * as assert from "assert";
+import { IdentityDescriptor } from "@dfinity/agent";
 import { useValue } from "@repeaterjs/react-hooks";
+import { makeLog } from "./log";
 
 interface AuthenticationState {
     identity: Readonly<IdentityDescriptor>

--- a/wallet_ui/components/App.tsx
+++ b/wallet_ui/components/App.tsx
@@ -28,7 +28,7 @@ import { Authorize } from "./routes/Authorize";
 import { Dashboard } from "./routes/Dashboard";
 import { useLocalStorage } from "../utils/hooks";
 import { KeyedLocalStorage, readOrCreateSession, Session } from "../session";
-import { makeLog } from "@dfinity/agent";
+import { makeLog } from "../log";
 import { useInternetComputerAuthentication } from "../authentication-react";
 
 export function Copyright() {

--- a/wallet_ui/components/authentication/AuthenticationButton.tsx
+++ b/wallet_ui/components/authentication/AuthenticationButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Button from "@material-ui/core/Button";
-import { makeLog } from "@dfinity/agent";
 import { authenticator } from "@dfinity/authentication";
+import { makeLog } from "../../log";
 import { AuthenticatorSession, Session } from "../../session";
 
 const log = makeLog('AuthenticationButton')

--- a/wallet_ui/components/routes/Authorize.tsx
+++ b/wallet_ui/components/routes/Authorize.tsx
@@ -24,7 +24,7 @@ import Box from "@material-ui/core/Box";
 import { Copyright } from "../App";
 import AuthenticationButton from "../authentication/AuthenticationButton";
 import AuthenticationContext from "../authentication/AuthenticationContext";
-import { makeLog } from "@dfinity/agent";
+import { makeLog } from "../../log";
 
 SyntaxHighlighter.registerLanguage("bash", bash);
 SyntaxHighlighter.registerLanguage("plaintext", plaintext);

--- a/wallet_ui/log/index.ts
+++ b/wallet_ui/log/index.ts
@@ -1,0 +1,1 @@
+export * from "./log";

--- a/wallet_ui/log/log.test.ts
+++ b/wallet_ui/log/log.test.ts
@@ -1,0 +1,12 @@
+import * as logModule from './log';
+
+test('makeLog(logName)(logLevel, ...loggables)', () => {
+  expect(typeof logModule.makeLog).toEqual('function');
+  const log = logModule.makeLog('logName');
+  expect(typeof log).toEqual('function');
+  expect(logWithoutLevel).toThrow();
+  function logWithoutLevel() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (log as any)();
+  }
+});

--- a/wallet_ui/log/log.ts
+++ b/wallet_ui/log/log.ts
@@ -1,0 +1,34 @@
+export type DefaultLogLevel = 'debug' | 'warn' | 'info' | 'error';
+export type LogFunction<Level extends DefaultLogLevel> = (
+  level: Level,
+  ...loggables: unknown[]
+) => void;
+
+/**
+ * Log something using globalThis.console, if present.
+ * @param level - log level. 'debug' shouldn't show in js console unless developers want it.
+ * @param loggables - variable arguments passed to `console.log(...)`
+ */
+export function log<Level extends DefaultLogLevel>(level: Level, ...loggables: unknown[]): void {
+  if (level in console && typeof console[level] === 'function') {
+    console[level](...loggables);
+    return;
+  }
+  if (!level) {
+    throw new Error(`log level is required, but not provided`);
+  }
+  if (level !== 'info') {
+    // unknown level, use 'info'
+    log('info', level, ...loggables);
+  }
+}
+
+/**
+ * Make a log function that logs messages prefixed with a logger name
+ * @param name - logger name to prepend before log messages
+ */
+export function makeLog<Level extends DefaultLogLevel>(name: string): LogFunction<Level> {
+  return (level: Level, ...loggables: unknown[]) => {
+    log(level, `[${name}]`, ...loggables);
+  };
+}

--- a/wallet_ui/session.ts
+++ b/wallet_ui/session.ts
@@ -1,5 +1,6 @@
-import { blobFromUint8Array, makeLog, SignIdentity } from "@dfinity/agent";
+import { blobFromUint8Array, SignIdentity } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/authentication";
+import { makeLog } from "./log";
 
 export interface KeyedLocalStorage {
   key: string;


### PR DESCRIPTION
I really really like to have these separately-prefixed logs around (silly/trace loglevel) to make sense of things even though they're not strictly needed. But @hansl has a good suggestion to not expose it from these `@dfinity/a...` libraries since they're already big enough.

This PR at least makes the import come from local. I'd love to change the exact implementation of this codebases log module to use other tools like `debug` or `loglevel` (on npm), but let's just improve that logging 'functionality' as a followup. My priority now is just making the imports work with what's in https://github.com/dfinity/agent-js 'next'

Unblocks:
* changing the package.json dep on agent,authentication to not use pre-release (which has the since-removed `makeLog`)