### PR TITLE
chore: Remove dep on repeaterjs/react-hooks and IdentitiesIterable from prerelease @dfinity/authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,19 +1623,6 @@
         "react-is": "^16.8.0 || ^17.0.0"
       }
     },
-    "@repeaterjs/react-hooks": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/react-hooks/-/react-hooks-0.1.1.tgz",
-      "integrity": "sha512-3aYv5taEVA62gd6EKBzwfcJl4asMy9t4Yjh0FrZ4A5pmY3gjb6tkes0xgTshDu90OALlo1lbVbTlfonXYyEBQQ==",
-      "requires": {
-        "@repeaterjs/repeater": "^3.0.1"
-      }
-    },
-    "@repeaterjs/repeater": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
-    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@dfinity/authentication": "0.0.0-identity-provider.0",
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
-    "@repeaterjs/react-hooks": "^0.1.1",
     "@types/react-router-dom": "^5.1.6",
     "@types/react-timeago": "^4.1.2",
     "assert": "^2.0.0",


### PR DESCRIPTION
Hans had asked me to remove these parts of the API before merging https://github.com/dfinity/agent-js/pull/132