### PR TITLE
feat: a wallet calling itself can access custodial methods

### DIFF
--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -525,7 +525,7 @@ mod wallet {
     async fn call(args: CallCanisterArgs) -> CallResult {
         if api::id() == caller() {
             // TODO: Return Err as a part of https://github.com/dfinity/wallet-rs/issues/32
-            ic_cdk::trap("Attempted to call forward on self. This is not allowed. Call this method via an different custodian.");
+            ic_cdk::trap("Attempted to call forward on self. This is not allowed. Call this method via a different custodian.");
         }
 
         match api::call::call_raw(


### PR DESCRIPTION
```
➜  custom git:(master) ✗ dfx canister call rwlgt-iiaaa-aaaaa-aaaaa-cai wallet_call '(record { canister = principal "rwlgt-iiaaa-aaaaa-aaaaa-cai"; method_name = "get_controllers";  args = blob "DIDL\00\00"; cycles = (0:nat64)})'
The Replica returned an error: code 5, message: "Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: An error happened during the call: 5: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: Attempted to call forward on self. This is not allowed. Call this method via an different custodian."

➜  custom git:(master) ✗ dfx canister --no-wallet call rwlgt-iiaaa-aaaaa-aaaaa-cai wallet_call '(record { canister = principal "rwlgt-iiaaa-aaaaa-aaaaa-cai"; method_name = "get_controllers";  args = blob "DIDL\00\00"; cycles = (0:nat64)})'
(
  record {
    153_986_224 = blob "DIDL\01mh\01\00\01\01\1d\07\af'\0c;[\ff\cd\7f\0a\a5&]i\ed\c6\af\d3\d5\cf\8d\9e\cfx\ca\1f\a1\91\02";
  },
)

➜  custom git:(master) ✗ dfx canister call rwlgt-iiaaa-aaaaa-aaaaa-cai wallet_balance '()'
(record { 3_573_748_184 = 100_000_000_000_000 })
```