### PR TITLE
Local dx updates for dfx@0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ The DFINITY Cycles Wallet implementation.
 
 - Install dependencies: `npm ci`
 - Start replica: `dfx start --background --clean`
-- Deploy to replica locally: `dfx deploy`
+- Deploy to replica locally: `dfx deploy --no-wallet`
 - Get canister ID: `dfx canister id wallet`
 - Open wallet UI at `http://localhost:8000/?canisterId=<wallet_canister_id_here>`

--- a/wallet_ui/utils/authClient.ts
+++ b/wallet_ui/utils/authClient.ts
@@ -15,6 +15,7 @@ class AuthClientWrapper {
   async login(): Promise<Identity | undefined> {
     return new Promise(async (resolve) => {
       return await this.authClient?.login({
+        identityProvider: this.identityProvider,
         onSuccess: async () => {
           resolve(await this.authClient?.getIdentity());
         },
@@ -28,6 +29,16 @@ class AuthClientWrapper {
 
   async isAuthenticated() {
     return await this.authClient?.isAuthenticated();
+  }
+
+  /**
+   * Get the internet-identity identityProvider URL to use when authenticating the end-user.
+   * Use ?identityProvider if present (useful in development), otherwise return undefined
+   * so that AuthClient default gets used.
+   */
+  private get identityProvider(): string|undefined {
+    const fromUrl = (new URLSearchParams(location.search)).get('identityProvider')
+    return fromUrl || undefined;
   }
 }
 


### PR DESCRIPTION
* Update README to deploy with `--no-wallet` so that the 'register device' screen command's `dfx call --no-wallet` works.
* The internet-identity URL used by `AuthClientWrapper#login` can be overridden via an `identityProvider` query string parameter in the URL. This is needed to test against a local instance of internet-identity, which [seems necessary](https://dfinity.slack.com/archives/C011E32H797/p1622660612030200?thread_ts=1622654790.023800&cid=C011E32H797) when running everything locally.
