### PR TITLE
feat: add support for multiple controllers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update 1.47.0 --no-self-update
-          rustup default 1.47.0
+          rustup update 1.52.1 --no-self-update
+          rustup default 1.52.1
           rustup target add wasm32-unknown-unknown
 
       - name: Install DFINITY SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added wallet_api_version() method
 - Added CanisterSettings field: controllers
-  - If present, the controller field will be ignored by this canister, and will be passed through as None to the IC.
+  - Either the controller field or the controllers field may be present, but not both.
 - Support for certified assets and http_request() interface.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-09-03
+
 ### Added
 
 - Added wallet_api_version() method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added wallet_api_version() method
-- Added CanisterSettings field: controllers
+- Added wallet_api_version() method.
+- Added 'controllers' field to CanisterSettings field.
   - Either the controller field or the controllers field may be present, but not both.
 - Support for certified assets and http_request() interface.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- wallet_api_version() method
+- CanisterSettings field: controllers
+    - If present, the controller field will be ignored by this canister, and will be
+passed through as None to the IC.
+- certified assets with http_request interface
+
+### Changed
+
+- The frontend now formats cycle balances in a human readable format, for example 5 KC = 5000 cycles, 10 TC = 10 trillion cycles 
+
+## 0.1.0 - 2021-06-06
+
+dfinity/wallet-rs@e902708
+
+module hash: 1404b28b1c66491689b59e184a9de3c2be0dbdd75d952f29113b516742b7f898
+
+### Fixed
+
+- The last controller may no longer be removed as a controller.
+
+### Changed
+
+- Differentiate between controllers and custodians.
+- deauthorize() will now only deauthorize custodians.
+
+## 0.1.0 - 2021-05-17
+
+https://github.com/dfinity/wallet-rs/commit/06bb256ca0738640be51cf84caaced7ea02ca29d
+module hash: a609400f2576d1d6df72ce868b359fd08e1d68e58454ef17db2361d2f1c242a1
+
+### Changed
+
+- Updated to use the Internet Identity Service.
+
+## 0.1.0 - 2021-04-30
+
+dfinity/wallet-rs@c3cbfc501564da89e669a2d9de810d32240baf5f
+module hash: 3d5b221387875574a9fd75b3165403cf1b301650a602310e9e4229d2f6766dcc
+
+### Fixed
+
+- Return correct content type and encoding for non-gz files
+- Updated frontend for canister creation settings
+
+## 0.1.0 - 2021-04-29
+
+module hash: ca5fa9c4c40194538619928415875a7d757e0b838b3eab545245505d71dd04fe
+
+update to spec 0.17.0
+
+### Changed
+
+- wallet_create_canister create argument with canister settings
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added wallet_api_version() method
 - Added CanisterSettings field: controllers
-    - If present, the controller field will be ignored by this canister, and will be
-passed through as None to the IC.
+  - If present, the controller field will be ignored by this canister, and will be passed through as None to the IC.
 - Support for certified assets and http_request() interface.
 
 ### Changed

--- a/e2e/bash/controller.bash
+++ b/e2e/bash/controller.bash
@@ -22,6 +22,9 @@ teardown() {
 }
 
 @test "canister creation sets controller to the wallet" {
+    # invokes:
+    #  - wallet_create_canister
+
     assert_command dfx identity new alice
     assert_command dfx identity use alice
 
@@ -42,6 +45,9 @@ teardown() {
 }
 
 @test "canister installation sets controller to the wallet" {
+    # invokes:
+    #  - wallet_create_canister
+
     assert_command dfx identity new alice
     assert_command dfx identity use alice
 
@@ -61,6 +67,9 @@ teardown() {
 }
 
 @test "update-settings sets controller" {
+    # invokes:
+    #  - wallet_create_canister
+
     assert_command dfx identity new alice
     assert_command dfx identity new bob
 
@@ -92,6 +101,11 @@ teardown() {
 }
 
 @test "wallet create wallet" {
+    # invokes:
+    #  - wallet_create_wallet
+    #  - update_settings_call
+    #  - update_settings_call (with controller)
+
     # curious: the cycles wallet has a wallet_create_wallet method, published
     # in its .did file.  dfx doesn't call it.  Maybe other users of the agent call it, though.
     # The sdk repo has one call to the method in an e2e ref test.  This is a copy of that test.

--- a/e2e/bash/controller.bash
+++ b/e2e/bash/controller.bash
@@ -21,37 +21,6 @@ teardown() {
     rm -rf "$DFX_CONFIG_ROOT"
 }
 
-@test "create wallet with multiple controllers, other than caller, through wallet_create_wallet" {
-    # invokes:
-    #  - wallet_create_wallet
-    #  - update_settings_call
-    #  - update_settings_call (with controllers)
-
-    assert_command dfx identity new alice
-    assert_command dfx identity new bob
-
-    # curious: the cycles wallet has a wallet_create_wallet method, published
-    # in its .did file.  dfx doesn't call it.  Maybe other users of the agent call it, though.
-    # The sdk repo has one call to the method in an e2e ref test.  This is a copy of that test.
-    WALLET_ID=$(dfx identity get-wallet)
-    CREATE_RES=$(dfx canister --no-wallet call "${WALLET_ID}" wallet_create_wallet "(record { cycles = (2000000000000:nat64); settings = record {controllers = opt vec { principal \"$(dfx --identity alice identity get-principal)\"; principal \"$(dfx --identity bob identity get-principal)\";};};})")
-    CHILD_ID=$(echo "${CREATE_RES}" | tr '\n' ' ' |  cut -d'"' -f 2)
-
-    assert_command_fail dfx canister --no-wallet call "${CHILD_ID}" wallet_balance '()'
-    assert_command dfx --identity alice canister --no-wallet call "${CHILD_ID}" wallet_balance '()'
-    assert_command dfx --identity bob canister --no-wallet call "${CHILD_ID}" wallet_balance '()'
-
-    assert_command_fail dfx canister --no-wallet call "${CHILD_ID}" get_custodians '()'
-    assert_command dfx --identity bob canister --no-wallet call "${CHILD_ID}" get_custodians '()'
-    assert_eq '(vec {})'
-
-    assert_command_fail dfx canister --no-wallet call "${CHILD_ID}" get_controllers '()'
-    assert_command dfx --identity alice canister --no-wallet call "${CHILD_ID}" get_controllers '()'
-    assert_not_match "$(dfx identity get-principal)"
-    assert_match 'principal "'"$(dfx --identity bob identity get-principal)"'"';
-    assert_match 'principal "'"$(dfx --identity alice identity get-principal)"'"';
-}
-
 @test "canister creation sets controller to the wallet" {
     # invokes:
     #  - wallet_create_canister
@@ -131,7 +100,7 @@ teardown() {
     assert_command dfx --identity bob canister install e2e_project -m reinstall
 }
 
-@test "wallet create wallet" {
+@test "create wallet with single controller through wallet_create_wallet" {
     # invokes:
     #  - wallet_create_wallet
     #  - update_settings_call
@@ -139,7 +108,8 @@ teardown() {
 
     # curious: the cycles wallet has a wallet_create_wallet method, published
     # in its .did file.  dfx doesn't call it.  Maybe other users of the agent call it, though.
-    # The sdk repo has one call to the method in an e2e ref test.  This is a copy of that test.
+    # The sdk repo has one call to the method in an e2e ref test.  This is a copy of that test,
+    # there called "wallet create wallet".
     WALLET_ID=$(dfx identity get-wallet)
     CREATE_RES=$(dfx canister --no-wallet call "${WALLET_ID}" wallet_create_wallet "(record { cycles = (2000000000000:nat64); settings = record {controller = opt principal \"$(dfx identity get-principal)\";};})")
     CHILD_ID=$(echo "${CREATE_RES}" | tr '\n' ' ' |  cut -d'"' -f 2)
@@ -155,9 +125,6 @@ teardown() {
     assert_command dfx identity new alice
     assert_command dfx identity new bob
 
-    # curious: the cycles wallet has a wallet_create_wallet method, published
-    # in its .did file.  dfx doesn't call it.  Maybe other users of the agent call it, though.
-    # The sdk repo has one call to the method in an e2e ref test.  This is a copy of that test.
     WALLET_ID=$(dfx identity get-wallet)
     CREATE_RES=$(dfx canister --no-wallet call "${WALLET_ID}" wallet_create_wallet "(record { cycles = (2000000000000:nat64); settings = record {controllers = opt vec { principal \"$(dfx identity get-principal)\"; principal \"$(dfx --identity alice identity get-principal)\";};};})")
     CHILD_ID=$(echo "${CREATE_RES}" | tr '\n' ' ' |  cut -d'"' -f 2)
@@ -170,6 +137,34 @@ teardown() {
     assert_eq '(vec {})'
     assert_command dfx canister --no-wallet call "${CHILD_ID}" get_controllers '()'
     assert_match 'principal "'"$(dfx identity get-principal)"'"';
+    assert_match 'principal "'"$(dfx --identity alice identity get-principal)"'"';
+}
+
+@test "create wallet with multiple controllers, other than caller, through wallet_create_wallet" {
+    # invokes:
+    #  - wallet_create_wallet
+    #  - update_settings_call
+    #  - update_settings_call (with controllers)
+
+    assert_command dfx identity new alice
+    assert_command dfx identity new bob
+
+    WALLET_ID=$(dfx identity get-wallet)
+    CREATE_RES=$(dfx canister --no-wallet call "${WALLET_ID}" wallet_create_wallet "(record { cycles = (2000000000000:nat64); settings = record {controllers = opt vec { principal \"$(dfx --identity alice identity get-principal)\"; principal \"$(dfx --identity bob identity get-principal)\";};};})")
+    CHILD_ID=$(echo "${CREATE_RES}" | tr '\n' ' ' |  cut -d'"' -f 2)
+
+    assert_command_fail dfx canister --no-wallet call "${CHILD_ID}" wallet_balance '()'
+    assert_command dfx --identity alice canister --no-wallet call "${CHILD_ID}" wallet_balance '()'
+    assert_command dfx --identity bob canister --no-wallet call "${CHILD_ID}" wallet_balance '()'
+
+    assert_command_fail dfx canister --no-wallet call "${CHILD_ID}" get_custodians '()'
+    assert_command dfx --identity bob canister --no-wallet call "${CHILD_ID}" get_custodians '()'
+    assert_eq '(vec {})'
+
+    assert_command_fail dfx canister --no-wallet call "${CHILD_ID}" get_controllers '()'
+    assert_command dfx --identity alice canister --no-wallet call "${CHILD_ID}" get_controllers '()'
+    assert_not_match "$(dfx identity get-principal)"
+    assert_match 'principal "'"$(dfx --identity bob identity get-principal)"'"';
     assert_match 'principal "'"$(dfx --identity alice identity get-principal)"'"';
 }
 

--- a/e2e/bash/version.bash
+++ b/e2e/bash/version.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC1090
+source "$BATS_SUPPORT"/load.bash
+
+load util/assertions
+
+setup() {
+    # We want to work from a temporary directory, different for every test.
+    x=$(mktemp -d -t dfx-usage-env-home-XXXXXXXX)
+    cd "$x" || exit
+    export DFX_CONFIG_ROOT=$x
+
+    dfx new --no-frontend e2e_project
+    cd e2e_project || exit 1
+    dfx start --background
+}
+
+teardown() {
+    dfx stop
+    rm -rf "$DFX_CONFIG_ROOT"
+}
+
+@test "reports the wallet API version" {
+    WALLET_ID=$(dfx identity get-wallet)
+    assert_command dfx canister --no-wallet call "${WALLET_ID}" wallet_api_version "()"
+    assert_eq '("0.2.0")'
+}

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -73,6 +73,7 @@ type WalletResultCall = variant {
 
 type CanisterSettings = record {
   controller: opt principal;
+  controllers: opt vec principal;
   compute_allocation: opt nat;
   memory_allocation: opt nat;
   freezing_threshold: opt nat;

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -117,8 +117,7 @@ type StreamingStrategy = variant {
 };
 
 service : {
-  // Wallet API Version
-  version: () -> (text) query;
+  wallet_api_version: () -> (text) query;
 
   // Wallet Name
   name: () -> (opt text) query;

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -116,6 +116,9 @@ type StreamingStrategy = variant {
 };
 
 service : {
+  // Wallet API Version
+  version: () -> (text) query;
+
   // Wallet Name
   name: () -> (opt text) query;
   set_name: (text) -> ();

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -95,7 +95,7 @@ fn post_upgrade() {
  * Wallet API Version
  **************************************************************************************************/
 #[query(guard = "is_custodian_or_controller")]
-fn version() -> String {
+fn wallet_api_version() -> String {
     WALLET_API_VERSION.to_string()
 }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -416,8 +416,8 @@ mod wallet {
     }
 
     fn make_valid_canister_settings(settings: CanisterSettings) -> CanisterSettings {
-        // Agent <= 0.7.0, dfx <= 0.8.1 will send controller
-        // Agents >= 0.?.?, dfx >= 0.?.? will send controllers
+        // Agent <= 0.8.0, dfx <= 0.8.1 will send controller
+        // Agents >= 0.9.0, dfx >= 0.8.2 will send controllers
         // The IC accept either controller or controllers, but not both.
         CanisterSettings {
             controller: if settings.controllers.is_some() {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -96,7 +96,7 @@ fn post_upgrade() {
  **************************************************************************************************/
 #[query(guard = "is_custodian_or_controller")]
 fn wallet_api_version() -> String {
-    ic_cdk::trap("wallet_api_version");
+    // yes ic_cdk::trap("wallet_api_version");
     WALLET_API_VERSION.to_string()
 }
 
@@ -422,7 +422,7 @@ mod wallet {
         // The IC accept either controller or controllers, but not both.
         CanisterSettings {
             controller: if settings.controllers.is_some() {
-                ic_cdk::trap("make_valid_canister_settings (controllers)");
+                // yes ic_cdk::trap("make_valid_canister_settings (controllers)");
 
                 None
             } else {
@@ -475,14 +475,14 @@ mod wallet {
 
         if update_acl {
             if let Some(controllers) = args.settings.controllers.as_ref() {
-                ic_cdk::trap("update_settings_call (controllers set)");
+                // yes ic_cdk::trap("update_settings_call (controllers set)");
                 for controller in controllers {
                     match api::call::call(
                         args.canister_id.clone(),
                         "add_controller",
                         (controller.clone(),),
                     )
-                        .await
+                    .await
                     {
                         Ok(x) => x,
                         Err((code, msg)) => {
@@ -500,7 +500,7 @@ mod wallet {
                     "add_controller",
                     (controller.clone(),),
                 )
-                    .await
+                .await
                 {
                     Ok(x) => x,
                     Err((code, msg)) => {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -96,7 +96,6 @@ fn post_upgrade() {
  **************************************************************************************************/
 #[query(guard = "is_custodian_or_controller")]
 fn wallet_api_version() -> String {
-    // yes ic_cdk::trap("wallet_api_version");
     WALLET_API_VERSION.to_string()
 }
 
@@ -422,12 +421,8 @@ mod wallet {
         // The IC accept either controller or controllers, but not both.
         CanisterSettings {
             controller: if settings.controllers.is_some() {
-                // yes ic_cdk::trap("make_valid_canister_settings (controllers)");
-
                 None
             } else {
-                // yes ic_cdk::trap("make_valid_canister_settings (controller)");
-
                 settings.controller
             },
             ..settings
@@ -471,11 +466,8 @@ mod wallet {
         args: UpdateSettingsArgs,
         update_acl: bool,
     ) -> Result<(), String> {
-        // yes ic_cdk::trap("update_settings_call");
-
         if update_acl {
             if let Some(controllers) = args.settings.controllers.as_ref() {
-                // yes ic_cdk::trap("update_settings_call (controllers set)");
                 for controller in controllers {
                     match api::call::call(
                         args.canister_id.clone(),
@@ -494,7 +486,6 @@ mod wallet {
                     };
                 }
             } else if let Some(controller) = args.settings.controller {
-                // yes ic_cdk::trap("update_settings_call (controller set)");
                 match api::call::call(
                     args.canister_id.clone(),
                     "add_controller",
@@ -524,8 +515,6 @@ mod wallet {
                 }
             };
         }
-
-        // yes ic_cdk::trap("update_settings_call (UpdateSettingsArgs)");
 
         let args = UpdateSettingsArgs {
             settings: make_valid_canister_settings(args.settings),
@@ -637,8 +626,6 @@ mod wallet {
 
         // Set controller
         if args.settings.controller.is_some() || args.settings.controllers.is_some() {
-            // yes ic_cdk::trap("create_wallet (controller or controllers set)");
-
             update_settings_call(
                 UpdateSettingsArgs {
                     canister_id: create_result.canister_id.clone(),

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -96,6 +96,7 @@ fn post_upgrade() {
  **************************************************************************************************/
 #[query(guard = "is_custodian_or_controller")]
 fn wallet_api_version() -> String {
+    ic_cdk::trap("wallet_api_version");
     WALLET_API_VERSION.to_string()
 }
 
@@ -421,8 +422,12 @@ mod wallet {
         // The IC accept either controller or controllers, but not both.
         CanisterSettings {
             controller: if settings.controllers.is_some() {
+                ic_cdk::trap("make_valid_canister_settings (controllers)");
+
                 None
             } else {
+                // yes ic_cdk::trap("make_valid_canister_settings (controller)");
+
                 settings.controller
             },
             ..settings
@@ -466,8 +471,11 @@ mod wallet {
         args: UpdateSettingsArgs,
         update_acl: bool,
     ) -> Result<(), String> {
+        // yes ic_cdk::trap("update_settings_call");
+
         if update_acl {
             if let Some(controllers) = args.settings.controllers.as_ref() {
+                ic_cdk::trap("update_settings_call (controllers set)");
                 for controller in controllers {
                     match api::call::call(
                         args.canister_id.clone(),
@@ -486,6 +494,7 @@ mod wallet {
                     };
                 }
             } else if let Some(controller) = args.settings.controller {
+                // yes ic_cdk::trap("update_settings_call (controller set)");
                 match api::call::call(
                     args.canister_id.clone(),
                     "add_controller",
@@ -515,6 +524,8 @@ mod wallet {
                 }
             };
         }
+
+        // yes ic_cdk::trap("update_settings_call (UpdateSettingsArgs)");
 
         let args = UpdateSettingsArgs {
             settings: make_valid_canister_settings(args.settings),
@@ -626,6 +637,8 @@ mod wallet {
 
         // Set controller
         if args.settings.controller.is_some() || args.settings.controllers.is_some() {
+            // yes ic_cdk::trap("create_wallet (controller or controllers set)");
+
             update_settings_call(
                 UpdateSettingsArgs {
                     canister_id: create_result.canister_id.clone(),


### PR DESCRIPTION
Make it so the cycles wallet accepts either a `controller` in `CanisterSettings` (as before), or alternatively a `controllers` field.  If a `controller` was passed, the cycles wallet now sends it through to the management canister in the `controllers` field.

Added a new method: `wallet_api_version`.
