### PR TITLE
feat: Track canisters and per-canister events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Managed canisters are now tracked, and the events that pertain to them are tracked under them.
+  - Added `list_managed_canisters`, `get_managed_canister_events`, and `set_short_name` functions.
+
+### Changed
+
+- `wallet_receive` now takes an optional memo parameter, for recording information about a particular transaction.
+
 ## [0.2.1] - 2021-12-03
 
 ### Changed

--- a/e2e/bash/events.bash
+++ b/e2e/bash/events.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# shellcheck source=/dev/null
+source "$BATS_SUPPORT/load.bash"
+load util/assertions
+
+setup() {
+    x=$(mktemp -d -t dfx-usage-env-home-XXXXXXXX)
+    cd "$x" || exit
+    export DFX_CONFIG_ROOT=$x
+
+    dfx new --no-frontend e2e_project
+    cd e2e_project || exit 1
+    dfx start --background
+}
+
+teardown() {
+    dfx stop
+    rm -rf "$DFX_CONFIG_ROOT"
+}
+
+@test "canister events are recorded correctly" {
+    WALLET=$(dfx identity get-wallet)
+    assert_command dfx deploy e2e_project
+    CANISTER=$(dfx canister id e2e_project)
+    # guaranteed to fail, but still reports the event
+    assert_command dfx canister --no-wallet call "$WALLET" wallet_send "(record { canister = principal \"$CANISTER\"; amount = 1000000000:nat64 })"
+    # 4449444c0001710d6379636c65735f77616c6c6574 = ("cycles_wallet")
+    assert_command dfx canister --no-wallet call "$WALLET" wallet_call "(record { canister = principal \"$CANISTER\"; cycles = 0:nat64; method_name = \"greet\"; args = vec { 0x44;0x49;0x44;0x4c;0x00;0x01;0x71;0x0d;0x63;0x79;0x63;0x6c;0x65;0x73;0x5f;0x77;0x61;0x6c;0x6c;0x65;0x74; }:blob})"
+    assert_command dfx canister --no-wallet call "$WALLET" list_managed_canisters '(record {})'
+    assert_match "23_515 = principal \"$CANISTER\";"
+    assert_command dfx canister --no-wallet call "$WALLET" get_managed_canister_events "(record { canister = principal \"$CANISTER\" })"
+    # CyclesSent=2171739429; Called=3950823581; Cretaed=3736853960
+    assert_match '3_736_853_960.*2_171_739_429.*3_950_823_581'
+}

--- a/e2e/bash/upgrade.bash
+++ b/e2e/bash/upgrade.bash
@@ -42,6 +42,6 @@ teardown() {
     # CanisterCreated = 1205528161; cycles = 2190693645; canister = 2631180839
     assert_match "1_205_528_161 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
     assert_command dfx canister --no-wallet call "$WALLET" get_managed_canister_events "(record { canister = principal \"$CANISTER\" })"
-    # Created = 3736853960; cyclels = 2190693645
+    # Created = 3736853960; cycles = 2190693645
     assert_match "3_736_853_960 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64"
 }

--- a/e2e/bash/upgrade.bash
+++ b/e2e/bash/upgrade.bash
@@ -31,7 +31,7 @@ teardown() {
         assert_command_fail dfx canister --no-wallet call "$WALLET" get_managed_canister_events "(record { canister = principal \"$CANISTER\" })"
         assert_command dfx canister --no-wallet call "$WALLET" get_events '(null)'
         # CanisterCreated = 1205528161; cycles = 2190693645; canister = 2631180839
-        assert_match "1_205_528_161 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
+        assert_match "1_205_528_161 = record \\{[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
     )
     # ^ reset DFX_WALLET_WASM
     assert_command [ -n "$DFX_WALLET_WASM" ]
@@ -40,8 +40,8 @@ teardown() {
     CANISTER=$(dfx canister id e2e_project)
     assert_command dfx canister --no-wallet call "$WALLET" get_events '(null)'
     # CanisterCreated = 1205528161; cycles = 2190693645; canister = 2631180839
-    assert_match "1_205_528_161 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
+    assert_match "1_205_528_161 = record \\{[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
     assert_command dfx canister --no-wallet call "$WALLET" get_managed_canister_events "(record { canister = principal \"$CANISTER\" })"
     # Created = 3736853960; cycles = 2190693645
-    assert_match "3_736_853_960 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64"
+    assert_match "3_736_853_960 = record \\{[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64"
 }

--- a/e2e/bash/upgrade.bash
+++ b/e2e/bash/upgrade.bash
@@ -35,7 +35,13 @@ teardown() {
     )
     # ^ reset DFX_WALLET_WASM
     assert_command [ -n "$DFX_WALLET_WASM" ]
+    assert_command dfx canister info "$(dfx identity get-wallet)"
+    assert_match "Module hash: 0x([0-9a-f]+)"
+    HASH=${BASH_REMATCH[1]}
+    assert_command [ -n "$HASH" ]
     assert_command dfx wallet upgrade
+    assert_command dfx canister info "$(dfx identity get-wallet)"
+    assert_not_match "$HASH"
     WALLET=$(dfx identity get-wallet)
     CANISTER=$(dfx canister id e2e_project)
     assert_command dfx canister --no-wallet call "$WALLET" get_events '(null)'

--- a/e2e/bash/upgrade.bash
+++ b/e2e/bash/upgrade.bash
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# shellcheck source=/dev/null
+source "$BATS_SUPPORT/load.bash"
+
+load util/assertions
+
+setup() {
+    # We want to work from a temporary directory, different for every test.
+    x=$(mktemp -d -t dfx-usage-env-home-XXXXXXXX)
+    cd "$x" || exit
+    export DFX_CONFIG_ROOT=$x
+    export DFX_VERSION=0.8.4
+
+    dfx new --no-frontend e2e_project
+    cd e2e_project || exit 1
+    dfx start --background
+}
+
+teardown() {
+    dfx stop
+    rm -rf "$DFX_CONFIG_ROOT"
+}
+
+@test "upgrading to new wallet version correctly migrates data" {
+    (
+        unset -v DFX_WALLET_WASM
+        assert_command dfx deploy --with-cycles 1000000000 e2e_project
+        WALLET=$(dfx identity get-wallet)
+        CANISTER=$(dfx canister id e2e_project)
+        assert_command_fail dfx canister --no-wallet call "$WALLET" get_managed_canister_events "(record { canister = principal \"$CANISTER\" })"
+        assert_command dfx canister --no-wallet call "$WALLET" get_events '(null)'
+        # CanisterCreated = 1205528161; cycles = 2190693645; canister = 2631180839
+        assert_match "1_205_528_161 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
+    )
+    # ^ reset DFX_WALLET_WASM
+    assert_command [ -n "$DFX_WALLET_WASM" ]
+    assert_command dfx wallet upgrade
+    WALLET=$(dfx identity get-wallet)
+    CANISTER=$(dfx canister id e2e_project)
+    assert_command dfx canister --no-wallet call "$WALLET" get_events '(null)'
+    # CanisterCreated = 1205528161; cycles = 2190693645; canister = 2631180839
+    assert_match "1_205_528_161 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64;[[:space:]]+2_631_180_839 = principal \"$CANISTER\""
+    assert_command dfx canister --no-wallet call "$WALLET" get_managed_canister_events "(record { canister = principal \"$CANISTER\" })"
+    # Created = 3736853960; cyclels = 2190693645
+    assert_match "3_736_853_960 = record {[[:space:]]+2_190_693_645 = 1_000_000_000 : nat64"
+}

--- a/wallet/Cargo.lock
+++ b/wallet/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "ic-cdk-macros",
  "ic-certified-map",
  "ic-types 0.1.5",
+ "indexmap",
  "libflate",
  "num-traits",
  "serde",

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1.0.116"
 serde_cbor = "0.11"
 serde_bytes = "0.11"
 serde_with = "1.6.2"
+indexmap = "1.7.0"
 
 [build-dependencies]
 sha2 = "0.9.1"

--- a/wallet/src/address.rs
+++ b/wallet/src/address.rs
@@ -120,14 +120,14 @@ impl AddressBook {
     pub fn remove(&mut self, principal: &Principal) {
         // Because we order by ID, we can create entries and remove them.
         self.0
-            .remove(&AddressEntry::new(principal.clone(), None, Role::Contact));
+            .remove(&AddressEntry::new(*principal, None, Role::Contact));
     }
 
     #[inline]
     pub fn take(&mut self, principal: &Principal) -> Option<AddressEntry> {
         // Because we order by ID, we can create entries and remove them.
         self.0
-            .take(&AddressEntry::new(principal.clone(), None, Role::Contact))
+            .take(&AddressEntry::new(*principal, None, Role::Contact))
     }
 
     #[inline]

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -161,7 +161,10 @@ impl EventKind {
             Self::CyclesSent { to, amount, refund } => {
                 Some((to, ChildEventKind::CyclesSent { amount, refund }))
             }
-            _ => None,
+            Self::AddressAdded { .. }
+            | Self::AddressRemoved { .. }
+            | Self::CyclesReceived { .. }
+            | Self::WalletDeployed { .. } => None,
         }
     }
 }

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -213,6 +213,7 @@ pub fn get_events(from: Option<u32>, to: Option<u32>) -> &'static [Event] {
     &buffer.as_slice()[from..to]
 }
 
+/// Return info about canisters managed by this wallet, as well as the total number of managed canisters.
 pub fn get_managed_canisters(
     from: Option<u32>,
     to: Option<u32>,

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -117,6 +117,7 @@ pub enum EventKind {
     CyclesReceived {
         from: Principal,
         amount: u64,
+        memo: Option<String>,
     },
     AddressAdded {
         id: Principal,

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -227,6 +227,9 @@ pub fn get_managed_canisters(
     )
 }
 
+/// Get a list of all events related to a specific managed canister. Returns `None` if the canister is unknown.
+/// 
+/// `from`, if unspecified, defaults to `len - 20`; `to`, if unspecified, defaults to `len`.
 pub fn get_managed_canister_events(
     canister: &Principal,
     from: Option<u32>,
@@ -244,14 +247,19 @@ pub fn get_managed_canister_events(
     Some(buffer[from..to].to_owned())
 }
 
+/// Changes the recorded short name of a canister. Returns the updated info, or `None` if this canister isn't known.
 pub fn set_short_name(canister: &Principal, name: Option<String>) -> Option<ManagedCanisterInfo> {
     let canister = storage::get_mut::<ManagedList>().0.get_mut(canister)?;
     canister.info.name = name;
     Some(canister.info.clone())
 }
 
+/// Migration functions to run on `#[post_upgrade]`.
 pub mod migrations {
     use super::*;
+    /// Creates the managed canister list from the event list. 
+    /// 
+    /// Call during `#[post_upgrade]`, after the event list is deserialized, if the canister list can't be deserialized.
     pub fn _1_create_managed_canister_list() {
         let managed = storage::get_mut::<ManagedList>();
         let events = storage::get_mut::<EventBuffer>();

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -50,7 +50,7 @@ pub struct ManagedCanister {
 pub struct ManagedCanisterInfo {
     pub id: Principal,
     pub name: Option<String>,
-    pub created_at: i64,
+    pub created_at: u64,
 }
 
 impl ManagedCanister {
@@ -59,7 +59,7 @@ impl ManagedCanister {
             info: ManagedCanisterInfo {
                 id,
                 name: None,
-                created_at: api::time() as i64,
+                created_at: api::time(),
             },
             events: vec![],
         }

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -4,10 +4,84 @@ use ic_cdk::export::Principal;
 use ic_cdk::{api, storage};
 use serde::Deserialize;
 use std::cmp::min;
+use std::collections::HashMap;
 
 #[derive(CandidType, Clone, Default, Deserialize)]
 pub struct EventBuffer {
     events: Vec<Event>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, CandidType, Deserialize)]
+pub struct ChildList(HashMap<Principal, Child>);
+
+impl ChildList {
+    pub fn push(&mut self, child: Principal, event: ChildEventKind) {
+        self.push_with_timestamp(child, event, api::time())
+    }
+    pub fn push_with_timestamp(&mut self, child: Principal, event: ChildEventKind, timestamp: u64) {
+        let events = &mut self
+            .0
+            .entry(child)
+            .or_insert_with(|| Child::new(child))
+            .events;
+        events.push(ChildEvent {
+            kind: event,
+            id: events.len() as u32,
+            timestamp,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, CandidType, Deserialize)]
+pub struct Child {
+    pub info: ChildInfo,
+    pub events: Vec<ChildEvent>,
+}
+
+#[derive(Debug, Clone, Eq, CandidType, Deserialize)]
+pub struct ChildInfo {
+    pub id: Principal,
+    pub name: Option<String>,
+    pub created_at: i64,
+}
+
+impl Child {
+    pub fn new(id: Principal) -> Self {
+        Self {
+            info: ChildInfo {
+                id,
+                name: None,
+                created_at: api::time() as i64,
+            },
+            events: vec![],
+        }
+    }
+}
+
+impl PartialEq for ChildInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl PartialEq for Child {
+    fn eq(&self, other: &Self) -> bool {
+        self.info == other.info
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+pub struct ChildEvent {
+    pub id: u32,
+    pub timestamp: u64,
+    pub kind: ChildEventKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+pub enum ChildEventKind {
+    CyclesSent { amount: u64, refund: u64 },
+    Called { method_name: String, cycles: u64 },
+    Created { cycles: u64 },
 }
 
 impl EventBuffer {
@@ -66,6 +140,31 @@ pub enum EventKind {
     },
 }
 
+impl EventKind {
+    pub fn to_child(&self) -> Option<(Principal, ChildEventKind)> {
+        match *self {
+            Self::CanisterCreated { cycles, canister } => {
+                Some((canister, ChildEventKind::Created { cycles }))
+            }
+            Self::CanisterCalled {
+                canister,
+                ref method_name,
+                cycles,
+            } => Some((
+                canister,
+                ChildEventKind::Called {
+                    method_name: method_name.clone(),
+                    cycles,
+                },
+            )),
+            Self::CyclesSent { to, amount, refund } => {
+                Some((to, ChildEventKind::CyclesSent { amount, refund }))
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(CandidType, Clone, Deserialize)]
 pub struct Event {
     pub id: u32,
@@ -76,6 +175,10 @@ pub struct Event {
 /// Record an event.
 pub fn record(kind: EventKind) {
     let buffer = storage::get_mut::<EventBuffer>();
+    if let Some((to, kind)) = kind.to_child() {
+        let children = storage::get_mut::<ChildList>();
+        children.push(to, kind);
+    }
     buffer.push(Event {
         id: buffer.len(),
         timestamp: api::time() as u64,
@@ -96,4 +199,48 @@ pub fn get_events(from: Option<u32>, to: Option<u32>) -> &'static [Event] {
     let to = min(buffer.len(), to.unwrap_or(u32::MAX)) as usize;
 
     &buffer.as_slice()[from..to]
+}
+
+pub fn get_children() -> Vec<&'static ChildInfo> {
+    storage::get::<ChildList>()
+        .0
+        .values()
+        .map(|x| &x.info)
+        .collect()
+}
+
+pub fn get_child_events(
+    child: &Principal,
+    from: Option<u32>,
+    to: Option<u32>,
+) -> Option<Vec<ChildEvent>> {
+    let buffer = &storage::get::<ChildList>().0.get(child)?.events;
+    let from = from.unwrap_or_else(|| {
+        if buffer.len() <= 20 {
+            0
+        } else {
+            buffer.len() as u32 - 20
+        }
+    }) as usize;
+    let to = min(buffer.len() as u32, to.unwrap_or(u32::MAX)) as usize;
+    Some(buffer[from..to].to_owned())
+}
+
+pub fn set_short_name(child: &Principal, name: Option<String>) -> Option<ChildInfo> {
+    let child = storage::get_mut::<ChildList>().0.get_mut(child)?;
+    child.info.name = name;
+    Some(child.info.clone())
+}
+
+pub mod migrations {
+    use super::*;
+    pub fn _1_create_child_list() {
+        let children = storage::get_mut::<ChildList>();
+        let events = storage::get_mut::<EventBuffer>();
+        for event in events.as_slice() {
+            if let Some((to, kind)) = event.kind.to_child() {
+                children.push_with_timestamp(to, kind, event.timestamp);
+            }
+        }
+    }
 }

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -60,7 +60,7 @@ type AddressEntry = record {
 type ManagedCanisterInfo = record {
   id: principal;
   name: opt text;
-  created_at: int64;
+  created_at: nat64;
 };
 
 type ManagedCanisterEventKind = variant {

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -57,13 +57,13 @@ type AddressEntry = record {
   role: Role;
 };
 
-type ChildInfo = record {
+type ManagedCanisterInfo = record {
   id: principal;
   name: opt text;
   created_at: int64;
 };
 
-type ChildEventKind = variant {
+type ManagedCanisterEventKind = variant {
   CyclesSent: record {
     amount: nat64;
     refund: nat64;
@@ -77,10 +77,10 @@ type ChildEventKind = variant {
   };
 };
 
-type ChildEvent = record {
+type ManagedCanisterEvent = record {
   id: nat32;
   timestamp: nat64;
-  kind: ChildEventKind;
+  kind: ManagedCanisterEventKind;
 };
 
 type ReceiveOptions = record {
@@ -196,11 +196,11 @@ service : {
   get_events: (opt record { from: opt nat32; to: opt nat32; }) -> (vec Event) query;
   get_chart: (opt record { count: opt nat32; precision: opt nat64; } ) -> (vec record { nat64; nat64; }) query;
 
-  // Children
-  list_children: () -> (vec ChildInfo) query;
+  // Managed canisters
+  list_managed_canisters: (record { from: opt nat32; to: opt nat32; }) -> (vec ManagedCanisterInfo, nat32) query;
   // If `from` is not specified, it will start 20 from the end; if `to` is not specified, it will stop at the end
-  get_child_events: (record { child: principal; from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
-  set_short_name: (principal, opt text) -> (opt ChildInfo);
+  get_managed_canister_events: (record { canister: principal; from: opt nat32; to: opt nat32; }) -> (opt vec ManagedCanisterEvent) query;
+  set_short_name: (principal, opt text) -> (opt ManagedCanisterInfo);
 
   // Assets
   http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -82,6 +82,10 @@ type ChildEvent = record {
   kind: ChildEventKind;
 };
 
+type ReceiveOptions = record {
+  memo: opt text;
+};
+
 type WalletResultCreate = variant {
   Ok : record { canister_id: principal };
   Err: text;
@@ -162,7 +166,7 @@ service : {
   // Cycle Management
   wallet_balance: () -> (record { amount: nat64 }) query;
   wallet_send: (record { canister: principal; amount: nat64 }) -> (WalletResult);
-  wallet_receive: () -> ();  // Endpoint for receiving cycles.
+  wallet_receive: (opt ReceiveOptions) -> ();  // Endpoint for receiving cycles.
 
   // Managing canister
   wallet_create_canister: (CreateCanisterArgs) -> (WalletResultCreate);

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -199,7 +199,7 @@ service : {
   // Children
   list_children: () -> (vec ChildInfo) query;
   // If `from` is not specified, it will start 20 from the end; if `to` is not specified, it will stop at the end
-  get_child_events: (record { child: principal, from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
+  get_child_events: (record { child: principal; from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
   set_short_name: (principal, opt text) -> (opt ChildInfo);
 
   // Assets

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -56,6 +56,32 @@ type AddressEntry = record {
   role: Role;
 };
 
+type ChildInfo = record {
+  id: principal;
+  name: opt text;
+  created_at: int64;
+};
+
+type ChildEventKind = variant {
+  CyclesSent: record {
+    amount: nat64;
+    refund: nat64;
+  };
+  Called: record {
+    method_name: text;
+    cycles: nat64;
+  };
+  Created: record {
+    cycles: nat64;
+  };
+};
+
+type ChildEvent = record {
+  id: nat32;
+  timestamp: nat64;
+  kind: ChildEventKind;
+};
+
 type WalletResultCreate = variant {
   Ok : record { canister_id: principal };
   Err: text;
@@ -163,6 +189,11 @@ service : {
   // Events
   get_events: (opt record { from: opt nat32; to: opt nat32; }) -> (vec Event) query;
   get_chart: (opt record { count: opt nat32; precision: opt nat64; } ) -> (vec record { nat64; nat64; }) query;
+
+  // Children
+  list_children: () -> (vec ChildInfo) query;
+  get_child_events: (principal, opt record { from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
+  set_short_name: (principal, opt text) -> (opt ChildInfo);
 
   // Assets
   http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -7,6 +7,7 @@ type EventKind = variant {
   CyclesReceived: record {
     from: principal;
     amount: nat64;
+    memo: opt text;
   };
   AddressAdded: record {
     id: principal;

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -192,11 +192,13 @@ service : {
   remove_address: (address: principal) -> (WalletResult);
 
   // Events
+  // If `from` is not specified, it will start 20 from the end; if `to` is not specified, it will stop at the end
   get_events: (opt record { from: opt nat32; to: opt nat32; }) -> (vec Event) query;
   get_chart: (opt record { count: opt nat32; precision: opt nat64; } ) -> (vec record { nat64; nat64; }) query;
 
   // Children
   list_children: () -> (vec ChildInfo) query;
+  // If `from` is not specified, it will start 20 from the end; if `to` is not specified, it will stop at the end
   get_child_events: (principal, opt record { from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
   set_short_name: (principal, opt text) -> (opt ChildInfo);
 

--- a/wallet/src/lib.did
+++ b/wallet/src/lib.did
@@ -199,7 +199,7 @@ service : {
   // Children
   list_children: () -> (vec ChildInfo) query;
   // If `from` is not specified, it will start 20 from the end; if `to` is not specified, it will stop at the end
-  get_child_events: (principal, opt record { from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
+  get_child_events: (record { child: principal, from: opt nat32; to: opt nat32; }) -> (opt vec ChildEvent) query;
   set_short_name: (principal, opt text) -> (opt ChildInfo);
 
   // Assets

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -759,16 +759,16 @@ fn list_children() -> Vec<&'static events::ChildInfo> {
     events::get_children()
 }
 
-#[query(guard = "is_custodian_or_controller")]
-fn get_child_events(
+#[derive(CandidType, Deserialize)]
+struct GetChildEventArgs {
     child: Principal,
-    args: Option<GetEventsArgs>,
-) -> Option<Vec<events::ChildEvent>> {
-    if let Some(GetEventsArgs { from, to }) = args {
-        events::get_child_events(&child, from, to)
-    } else {
-        events::get_child_events(&child, None, None)
-    }
+    from: Option<u32>,
+    to: Option<u32>,
+}
+
+#[query(guard = "is_custodian_or_controller")]
+fn get_child_events(args: GetChildEventArgs) -> Option<Vec<events::ChildEvent>> {
+    events::get_child_events(&args.child, args.from, args.to)
 }
 
 #[update(guard = "is_custodian_or_controller")]

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -337,9 +337,7 @@ mod wallet {
     /// Send cycles to another canister.
     #[update(guard = "is_custodian_or_controller", name = "wallet_send")]
     async fn send(args: SendCyclesArgs) -> Result<(), String> {
-        match api::call::call_with_payment(args.canister, "wallet_receive", (), args.amount)
-            .await
-        {
+        match api::call::call_with_payment(args.canister, "wallet_receive", (), args.amount).await {
             Ok(x) => {
                 let refund = api::call::msg_cycles_refunded();
                 events::record(events::EventKind::CyclesSent {
@@ -500,12 +498,7 @@ mod wallet {
             // assumption: settings are normalized (settings.controller is never present)
             if let Some(controllers) = args.settings.controllers.as_ref() {
                 for controller in controllers {
-                    match api::call::call(
-                        args.canister_id,
-                        "add_controller",
-                        (*controller,),
-                    )
-                    .await
+                    match api::call::call(args.canister_id, "add_controller", (*controller,)).await
                     {
                         Ok(x) => x,
                         Err((code, msg)) => {
@@ -591,13 +584,7 @@ mod wallet {
 
         // Store wallet wasm
         let store_args = WalletStoreWASMArgs { wasm_module };
-        match api::call::call(
-            *canister_id,
-            "wallet_store_wallet_wasm",
-            (store_args,),
-        )
-        .await
-        {
+        match api::call::call(*canister_id, "wallet_store_wallet_wasm", (store_args,)).await {
             Ok(x) => x,
             Err((code, msg)) => {
                 return Err(format!(
@@ -690,14 +677,7 @@ mod wallet {
             return Err("Attempted to call forward on self. This is not allowed. Call this method via a different custodian.".to_string());
         }
 
-        match api::call::call_raw(
-            args.canister,
-            &args.method_name,
-            args.args,
-            args.cycles,
-        )
-        .await
-        {
+        match api::call::call_raw(args.canister, &args.method_name, args.args, args.cycles).await {
             Ok(x) => {
                 events::record(events::EventKind::CanisterCalled {
                     canister: args.canister,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -370,9 +370,14 @@ mod wallet {
         Ok(())
     }
 
+    #[derive(CandidType, Deserialize)]
+    struct ReceiveOptions {
+        memo: Option<String>,
+    }
+
     /// Receive cycles from another canister.
     #[update(name = "wallet_receive")]
-    fn receive() {
+    fn receive(options: Option<ReceiveOptions>) {
         let from = caller();
         let amount = ic_cdk::api::call::msg_cycles_available();
         if amount > 0 {
@@ -380,6 +385,7 @@ mod wallet {
             events::record(events::EventKind::CyclesReceived {
                 from,
                 amount: amount_accepted,
+                memo: options.and_then(|opts| opts.memo)
             });
             super::update_chart();
         }


### PR DESCRIPTION
Addresses [SDK-231](https://dfinity.atlassian.net/jira/software/c/projects/SDK/boards/167/backlog?view=detail&selectedIssue=SDK-231&issueLimit=100&assignee=617cc0a5702bd0006a10179c).

Currently, the cycles wallet records a unified list of events, and does not remember what canisters it created. This pull makes it so that it does remember its child canisters, and records each child-canister-related event separately by canister. The old collections will still be around for compatibility and easy filtering; the two will just be kept in sync. An optional parameter is also added to wallet_receive for an optional transaction memo.