### PR TITLE
fix: Use deposit_cycles instead of wallet_receive

### DIFF
--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -334,10 +334,24 @@ mod wallet {
         }
     }
 
+    #[derive(CandidType)]
+    struct DepositCyclesArgs {
+        canister_id: Principal,
+    }
+
     /// Send cycles to another canister.
     #[update(guard = "is_custodian_or_controller", name = "wallet_send")]
     async fn send(args: SendCyclesArgs) -> Result<(), String> {
-        match api::call::call_with_payment(args.canister, "wallet_receive", (), args.amount).await {
+        match api::call::call_with_payment(
+            Principal::management_canister(),
+            "deposit_cycles",
+            (DepositCyclesArgs {
+                canister_id: args.canister,
+            },),
+            args.amount,
+        )
+        .await
+        {
             Ok(x) => {
                 let refund = api::call::msg_cycles_refunded();
                 events::record(events::EventKind::CyclesSent {


### PR DESCRIPTION
wallet_receive used to be a dedicated function for receiving cycles with. The current management canister has a deposit_cycles function to send cycles to a canister without that canister needing a function to receive them with, so this convention is no longer necessary.