### PR TITLE
fix: Redirect authorize endpoint to /index.html

### DIFF
--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -168,8 +168,10 @@ struct Token {}
 
 #[query]
 fn http_request(req: HttpRequest) -> HttpResponse {
-    let parts: Vec<&str> = req.url.split('?').collect();
-    let asset = parts[0];
+    let mut asset = req.url.split('?').next().unwrap_or("/");
+    if asset == "/authorize" {
+        asset = "/index.html";
+    }
     let assets = storage::get::<Assets>();
     let certificate_header = make_asset_certificate_header(&assets.hashes, asset);
     match assets.contents.get(asset) {


### PR DESCRIPTION
The wallet serves certified assets, but switching to the certified endpoint directly after authenticating gives the impression that it does not, because it is trying to certify the /authorize endpoint which is implemented by the client side and the canister has no certification for. This change serves /index.html for that endpoint, which can be a certified response to any request, and is what the client-side handling expects anyway.