### PR TITLE
fix: Limit event history size

### DIFF
--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -47,7 +47,7 @@ impl ManagedList {
             timestamp,
         });
         if events.len() > 1000 {
-            events.truncate(1000);
+            events.drain(..events.len() - 1000);
             canister.culled = Some(events[0].id as usize);
         }
     }
@@ -202,6 +202,7 @@ pub fn record(kind: EventKind) {
     }
     EVENT_BUFFER.with(|buffer| {
         let mut buffer = buffer.borrow_mut();
+        let buffer = &mut *buffer;
         let len = buffer.len();
         buffer.push(Event {
             id: len,
@@ -209,7 +210,7 @@ pub fn record(kind: EventKind) {
             kind,
         });
         if buffer.len() > 5000 {
-            buffer.events.truncate(5000);
+            buffer.events.drain(..buffer.events.len() - 5000);
             buffer.culled = Some(buffer.events[0].id as usize);
         }
     });

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -20,6 +20,9 @@ pub struct EventBuffer {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ManagedList(pub IndexMap<Principal, ManagedCanister>);
 
+const MAX_EVENTS: usize = 10_000;
+const MAX_CANISTER_EVENTS: usize = 1_000;
+
 thread_local! {
     pub static EVENT_BUFFER: RefCell<EventBuffer> = Default::default();
     pub static MANAGED_LIST: RefCell<ManagedList> = Default::default();
@@ -45,8 +48,8 @@ impl ManagedList {
             id: events.len() as u32,
             timestamp,
         });
-        if events.len() > 1000 {
-            events.drain(..events.len() - 1000);
+        if events.len() > MAX_CANISTER_EVENTS {
+            events.drain(..events.len() - MAX_EVENTS);
         }
     }
 }
@@ -208,8 +211,8 @@ pub fn record(kind: EventKind) {
             timestamp: api::time() as u64,
             kind,
         });
-        if buffer.events.len() > 10_000 {
-            buffer.events.drain(..buffer.events.len() - 10_000);
+        if buffer.events.len() > MAX_EVENTS {
+            buffer.events.drain(..buffer.events.len() - MAX_EVENTS);
         }
     });
 }

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -49,7 +49,7 @@ impl ManagedList {
             timestamp,
         });
         if events.len() > MAX_CANISTER_EVENTS {
-            events.drain(..events.len() - MAX_EVENTS);
+            events.drain(..events.len() - MAX_CANISTER_EVENTS);
         }
     }
 }

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -209,8 +209,8 @@ pub fn record(kind: EventKind) {
             timestamp: api::time() as u64,
             kind,
         });
-        if buffer.events.len() > 5000 {
-            buffer.events.drain(..buffer.events.len() - 5000);
+        if buffer.events.len() > 10_000 {
+            buffer.events.drain(..buffer.events.len() - 10_000);
             buffer.culled = Some(buffer.events[0].id as usize);
         }
     });

--- a/wallet/src/events.rs
+++ b/wallet/src/events.rs
@@ -121,7 +121,10 @@ impl EventBuffer {
     #[inline]
     pub fn between(&self, Range { start, end }: Range<usize>) -> Vec<Event> {
         let base = self.culled.unwrap_or(0);
-        self.events.range(start.saturating_sub(base)..end.saturating_sub(base)).cloned().collect()
+        self.events
+            .range(start.saturating_sub(base)..end.saturating_sub(base))
+            .cloned()
+            .collect()
     }
 }
 
@@ -262,16 +265,15 @@ pub fn get_managed_canister_events(
         let canister = &buffer.0.get(canister)?;
         let buffer = &canister.events;
         let total = buffer.back().map(|event| event.id).unwrap_or(0) + 1;
-        let from = from.unwrap_or_else(|| {
-            if total <= 20 {
-                0
-            } else {
-                total - 20
-            }
-        }) as usize;
+        let from = from.unwrap_or_else(|| if total <= 20 { 0 } else { total - 20 }) as usize;
         let to = min(total, to.unwrap_or(u32::MAX)) as usize;
         let base = canister.culled.unwrap_or(0);
-        Some(buffer.range(from.saturating_sub(base)..to.saturating_sub(base)).cloned().collect())
+        Some(
+            buffer
+                .range(from.saturating_sub(base)..to.saturating_sub(base))
+                .cloned()
+                .collect(),
+        )
     })
 }
 

--- a/wallet/src/migrations.rs
+++ b/wallet/src/migrations.rs
@@ -107,7 +107,6 @@ pub(crate) fn _2_convert_nat64_to_nat(
         .collect();
     let events = V2EventBuffer {
         events,
-        culled: Some(0),
     };
     let managed = managed
         .unwrap_or_default()
@@ -155,7 +154,6 @@ pub(crate) fn _2_convert_nat64_to_nat(
                 V2ManagedCanister {
                     info,
                     events,
-                    culled: Some(0),
                 },
             )
         })

--- a/wallet/src/migrations.rs
+++ b/wallet/src/migrations.rs
@@ -105,9 +105,7 @@ pub(crate) fn _2_convert_nat64_to_nat(
             },
         )
         .collect();
-    let events = V2EventBuffer {
-        events,
-    };
+    let events = V2EventBuffer { events };
     let managed = managed
         .unwrap_or_default()
         .0
@@ -149,13 +147,7 @@ pub(crate) fn _2_convert_nat64_to_nat(
                     },
                 )
                 .collect();
-            (
-                principal,
-                V2ManagedCanister {
-                    info,
-                    events,
-                },
-            )
+            (principal, V2ManagedCanister { info, events })
         })
         .collect();
     let managed = Some(V2ManagedList(managed));

--- a/wallet/src/migrations.rs
+++ b/wallet/src/migrations.rs
@@ -105,7 +105,7 @@ pub(crate) fn _2_convert_nat64_to_nat(
             },
         )
         .collect();
-    let events = V2EventBuffer { events };
+    let events = V2EventBuffer { events, culled: Some(0) };
     let managed = managed
         .unwrap_or_default()
         .0
@@ -147,7 +147,7 @@ pub(crate) fn _2_convert_nat64_to_nat(
                     },
                 )
                 .collect();
-            (principal, V2ManagedCanister { info, events })
+            (principal, V2ManagedCanister { info, events, culled: Some(0) })
         })
         .collect();
     let managed = Some(V2ManagedList(managed));

--- a/wallet/src/migrations.rs
+++ b/wallet/src/migrations.rs
@@ -105,7 +105,10 @@ pub(crate) fn _2_convert_nat64_to_nat(
             },
         )
         .collect();
-    let events = V2EventBuffer { events, culled: Some(0) };
+    let events = V2EventBuffer {
+        events,
+        culled: Some(0),
+    };
     let managed = managed
         .unwrap_or_default()
         .0
@@ -147,7 +150,14 @@ pub(crate) fn _2_convert_nat64_to_nat(
                     },
                 )
                 .collect();
-            (principal, V2ManagedCanister { info, events, culled: Some(0) })
+            (
+                principal,
+                V2ManagedCanister {
+                    info,
+                    events,
+                    culled: Some(0),
+                },
+            )
         })
         .collect();
     let managed = Some(V2ManagedList(managed));


### PR DESCRIPTION
Previously the wallet would record as many events as it could hold. This could result in a call running out of cycles when the vector needed to be reallocated. This sets a cap on events as 10,000 global events and 1,000 canister-specific events per canister.

Fixes #75.