### PR TITLE
chore: remove invalid flag from generated command

### DIFF
--- a/wallet_ui/components/routes/Authorize.tsx
+++ b/wallet_ui/components/routes/Authorize.tsx
@@ -119,7 +119,7 @@ export function Authorize(props: AuthorizeProps) {
   if (agentPrincipal && !agentPrincipal.isAnonymous()) {
     const canisterId = getWalletId();
     const isLocalhost = !!window.location.hostname.match(/^(.*\.)?localhost$/);
-    const canisterCallShCode = `dfx canister --no-wallet${
+    const canisterCallShCode = `dfx canister${
       isLocalhost ? "" : " --network ic"
     } call "${
       canisterId?.toText() || ""


### PR DESCRIPTION
the `--no-wallet` flag is not valid anymore in the latest versions of dfx